### PR TITLE
Allow for splat go run (*.go) and cleanup path parsing

### DIFF
--- a/bin/gomon
+++ b/bin/gomon
@@ -1,31 +1,31 @@
 #!/usr/bin/env node
 var fs          = require('fs');
+var path        = require('path');
 var spawn       = require('child_process').spawn;
 var exec        = require('child_process').exec;
-var argv        = require('minimist')(process.argv.slice(2));
+var args        = require('minimist')(process.argv.slice(2))._;
 var watch       = require('watch');
 var colorsTmpl  = require('colors');
 var gorun;
 
-// check
-if (argv._.length <= 0 || argv._ > 1) {
-  console.error('Use gomon like:', '\ngomon myfile.go'.green, '\nand not without any or multiple arguments!'.red);
+// Make sure we have arguments
+if (args.length <= 0 || args > 1) {
+  console.error([
+    'Use gomon like so:\n',
+    'gomon myfile.go\n'.green,
+    'or even:\n',
+    'gomon *.go\n'.green
+  ].join(''));
   process.exit(2);
-  return;
 }
 
-// setup
-var maindir = argv._[0].split("/");
-maindir.pop();
-maindir = maindir.join('/');
-maindir = maindir.length <= 0 ? process.cwd() : maindir;
-var processName = argv._[0].split("/").pop().split(".")[0];
-var path = argv._[0];
+// Discover work path
+var firstArgDir = path.dirname(args[0]);
+var mainDir = firstArgDir === '.' ? process.cwd() : firstArgDir;
+var processName = path.basename(args[0].name, '.go');
 
-// setting the GOPATH
-process.env.GOPATH = process.cwd() + (process.env.GOPATH && ":" + process.env.GOPATH || "");
 
-watch.createMonitor(maindir, function (monitor) {
+watch.createMonitor(mainDir, function (monitor) {
   monitor.files['.go'];
   monitor.on("created", killAll);
   monitor.on("changed", killAll);
@@ -33,9 +33,9 @@ watch.createMonitor(maindir, function (monitor) {
 });
 
 function run () {
-  console.log('go run'.green, path);
-  
-  gorun = spawn('go', ['run', path]);
+  console.log('go run'.green, args.join(', '));
+
+  gorun = spawn('go', ['run'].concat(args));
   gorun.stdout.on('data', function (data) {
     console.log('stdout: ' + data);
   });


### PR DESCRIPTION
`gomon` should be able to take multiple parameter as often when programming in Go you end up with multiple go files to pass in to `go run ...`.

The important change is in this line: `gorun = spawn('go', ['run'].concat(args));` concatenating all args passed in (as the shell expand `*.go` to `config.go main.go db.go`)

I also made the path guessing/setup/whatever a little bit nicer using the stdlib module 'path'.