### PR TITLE
First off, thanks for making this tool!

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Then just run a go programm like `gomon staticsmoothie.go`!
 
 ## Contributors
 
-- [ruandao](https://github.com/ruandao) 
+- [ruandao](https://github.com/ruandao)
 - [kiasaki](https://github.com/kiasaki)
+- [Khelldar](https://github.com/Khelldar)
 
 [![endorse](https://api.coderwall.com/johannesboyne/endorsecount.png)](https://coderwall.com/johannesboyne)

--- a/bin/gomon
+++ b/bin/gomon
@@ -41,7 +41,6 @@ function run () {
   //instead of running 'go run', we are going to split this into two operations
   //first, let's run go build and compile into a file called "gomon_spawn"
   var buildCommand = 'go build -o ' + BINARY_FILE
-  // console.log(buildCommand.green);
 
   exec(buildCommand, function (err, stdout, stderr) {
     if (err) {
@@ -61,21 +60,21 @@ function run () {
     //now that we have our binary, we can run that file.
     //This gives us a handle on the Pid we want (just running 'go run' spawns a child process running out of a temp dir)
     var runCommand = './' + BINARY_FILE
-    // console.log((runCommand + ' ' + procArgs.join(' ')).green);
     gorun = spawn('./ProcManager', procArgs, { stdio: 'inherit' });
   });
 }
 
-function conditionalKill(thing) {
+function conditionalKill(reason) {
   return function(f){
     if(!f.endsWith(BINARY_FILE)){
+      var message = '>> restarting due to ' +  reason + ' file: ' + f;
+      console.log(message.red);
       killAll()
     }
   }
 }
 
 function killAll () {
-  console.log('>> restart'.red);
   exec('kill '+gorun.pid, function (err, stdout, stderr) {
     run();
   });

--- a/bin/gomon
+++ b/bin/gomon
@@ -7,6 +7,9 @@ var args        = require('minimist')(process.argv.slice(2))._;
 var watch       = require('watch');
 var colorsTmpl  = require('colors');
 var gorun;
+var goFile;
+var procArgs;
+var BINARY_FILE = "gomon_spawn";
 
 // Make sure we have arguments
 if (args.length <= 0 || args > 1) {
@@ -19,34 +22,61 @@ if (args.length <= 0 || args > 1) {
   process.exit(2);
 }
 
+//entry to go program
+goFile = args[0]
+procArgs = process.argv.slice(3)
+
 // Discover work path
-var firstArgDir = path.dirname(args[0]);
+var firstArgDir = path.dirname(goFile);
 var mainDir = firstArgDir === '.' ? process.cwd() : firstArgDir;
-var processName = path.basename(args[0].name, '.go');
 
-
-watch.createMonitor(mainDir, function (monitor) {
-  monitor.files['.go'];
-  monitor.on("created", killAll);
-  monitor.on("changed", killAll);
-  monitor.on("removed", killAll);
+watch.createMonitor(mainDir, {ignoreDotFiles: true}, function (monitor) {
+  monitor.on("created", conditionalKill("created"));
+  monitor.on("changed", conditionalKill("changed"));
+  monitor.on("removed", conditionalKill("removed"));
 });
 
 function run () {
-  console.log('go run'.green, args.join(', '));
+  console.log('>> gomon'.green);
+  //instead of running 'go run', we are going to split this into two operations
+  //first, let's run go build and compile into a file called "gomon_spawn"
+  var buildCommand = 'go build -o ' + BINARY_FILE
+  // console.log(buildCommand.green);
 
-  gorun = spawn('go', ['run'].concat(args));
-  gorun.stdout.on('data', function (data) {
-    console.log('stdout: ' + data);
+  exec(buildCommand, function (err, stdout, stderr) {
+    if (err) {
+      console.error(err);
+      return;
+    }
+    if (stdout) {
+      //go build should not generate any output, so if something is here, it's a compile error and we need to bail
+      console.log(stdout);
+      return
+    }
+    if (stderr) {
+      console.error(stderr);
+      return
+    }
+
+    //now that we have our binary, we can run that file.
+    //This gives us a handle on the Pid we want (just running 'go run' spawns a child process running out of a temp dir)
+    var runCommand = './' + BINARY_FILE
+    // console.log((runCommand + ' ' + procArgs.join(' ')).green);
+    gorun = spawn('./ProcManager', procArgs, { stdio: 'inherit' });
   });
-  gorun.stderr.on('data', function (data) {
-    console.log('stderr: ' + data);
-  });
+}
+
+function conditionalKill(thing) {
+  return function(f){
+    if(!f.endsWith(BINARY_FILE)){
+      killAll()
+    }
+  }
 }
 
 function killAll () {
   console.log('>> restart'.red);
-  exec('killall '+processName, function (err, stdout, stderr) {
+  exec('kill '+gorun.pid, function (err, stdout, stderr) {
     run();
   });
 }


### PR DESCRIPTION
I ran into a few issues while working with this:
- go processes leaking
- using killall instead of killing processes by pid
- not passing in arguments to go program

This PR fixes these issues with a few small changes.  First off, args are now
being passed to the go process straight off of process.argsv.  Easy enough.
Preventing processes from leaking and killing by pid was a little trickier.  Before,
the 'go run' command was used.  Normally, this is fine, but due to how go compiles and runs
a separate process out of a temp directory, this means that the pid of our 'go run' process is different
than the sub-process that we actually want to kill.  To get around this, I've broken 'go run' into two commands.
First, 'go build -o gomon_spawn' is run, compiling binaries into 'gomon_spawn'.  If that worked, we can spawn
that binary directly.  Now we have the pid for killing later and there's no weird child processes to worry about.

Some other small tweaks included ignoring files that start with '.'.