### PR TITLE
fix `Cannot read property 'pid' of undefined`

### DIFF
--- a/bin/gomon
+++ b/bin/gomon
@@ -75,9 +75,12 @@ function conditionalKill(reason) {
 }
 
 function killAll () {
-  exec('kill '+gorun.pid, function (err, stdout, stderr) {
+  if (!gorun)
     run();
-  });
+  else
+    exec('kill '+gorun.pid, function (err, stdout, stderr) {
+      run();
+    });
 }
 
 run();


### PR DESCRIPTION
/usr/local/lib/node_modules/go-mon/bin/gomon:78
  exec('kill '+gorun.pid, function (err, stdout, stderr) {
                     ^

TypeError: Cannot read property 'pid' of undefined
    at killAll (/usr/local/lib/node_modules/go-mon/bin/gomon:78:22)
    at EventEmitter.<anonymous> (/usr/local/lib/node_modules/go-mon/bin/gomon:72:7)
    at EventEmitter.emit (events.js:182:13)
    at /usr/local/lib/node_modules/go-mon/node_modules/watch/main.js:118:13
    at StatWatcher.<anonymous> (/usr/local/lib/node_modules/go-mon/node_modules/watch/main.js:73:38)
    at StatWatcher.emit (events.js:182:13)
    at StatWatcher._handle.onchange (fs.js:1479:10)